### PR TITLE
feat: functions do not include return by default

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@
 
 <script setup>
 import { reactive, ref } from '@vue/reactivity'
-import { computed, onMounted } from '@vue/runtime-core'
+import { computed } from '@vue/runtime-core'
 import PlayCanvas from './components/PlayCanvas.vue'
 import TeamFunctionInput from './components/TeamFunctionInput.vue'
 import TeamCode from './components/TeamCode.vue'
@@ -62,24 +62,37 @@ import {
   placeTeam,
   updateTeam,
 } from './common/team'
-import { sanitize } from './common/strings'
 
 // This starter template is using Vue 3 experimental <script setup> SFCs
 // Check out https://github.com/vuejs/rfcs/blob/script-setup-2/active-rfcs/0000-script-setup.md
 
+const defaultTeamOne = {
+  moveX: 'return 1',
+  moveY: 'return 1',
+  placeX: 'return i * (GAME_SIZE / teamSize)',
+  placeY: 'return 0',
+};
+
+const defaultTeamTwo = {
+  moveX: 'return 1',
+  moveY: 'return -1',
+  placeX: 'return i * (GAME_SIZE / teamSize)',
+  placeY: 'return GAME_SIZE',
+};
+
 const teamOne = reactive({
-  moveX: '1',
-  moveY: '1',
-  placeX: 'i * (GAME_SIZE / teamSize)',
-  placeY: '0',
-})
+  moveX: defaultTeamOne.moveX,
+  moveY: defaultTeamOne.moveY,
+  placeX: defaultTeamOne.placeX,
+  placeY: defaultTeamOne.placeY
+});
 
 const teamTwo = reactive({
-  moveX: '1',
-  moveY: '-1',
-  placeX: 'i * (GAME_SIZE / teamSize)',
-  placeY: 'GAME_SIZE',
-})
+  moveX: defaultTeamTwo.moveX,
+  moveY: defaultTeamTwo.moveY,
+  placeX: defaultTeamTwo.placeX,
+  placeY: defaultTeamTwo.placeY
+});
 
 let isPaused = ref(false);
 let isPlaying = ref(false);
@@ -247,17 +260,17 @@ const loadTeam = (team, code) => {
   const obj = decodeTeam(code)
 
   if (team === 'one') {
-    teamOne.moveX = obj.moveX || '1'
-    teamOne.moveY = obj.moveY || '1'
-    teamOne.placeX = obj.placeX || 'i * 2'
-    teamOne.placeY = obj.placeY || '0'
+    teamOne.moveX = obj.moveX || defaultTeamOne.moveX;
+    teamOne.moveY = obj.moveY || defaultTeamTwo.moveY;
+    teamOne.placeX = obj.placeX || defaultTeamOne.placeX;
+    teamOne.placeY = obj.placeY || defaultTeamOne.placeY;
   }
 
   if (team === 'two') {
-    teamTwo.moveX = obj.moveX || '1'
-    teamTwo.moveY = obj.moveY || '1'
-    teamTwo.placeX = obj.placeX || 'i * 2'
-    teamTwo.placeY = obj.placeY || '0'
+    teamTwo.moveX = obj.moveX || defaultTeamTwo.moveX;
+    teamTwo.moveY = obj.moveY || defaultTeamTwo.moveY;
+    teamTwo.placeX = obj.placeX || defaultTeamTwo.placeX;
+    teamTwo.placeY = obj.placeY || defaultTeamTwo.placeY;
   }
 }
 

--- a/src/common/team.js
+++ b/src/common/team.js
@@ -13,7 +13,7 @@ export const createMoveFunction = (fnString) => {
     // "Hidden" args
     "teamSize",
     "teamPoints",
-    `const GAME_SIZE = ${GAME_SIZE}; return ${fnString}`
+    `const GAME_SIZE = ${GAME_SIZE}; ${fnString}`
   );
 };
 
@@ -22,7 +22,7 @@ export const createPlaceFunction = (fnString) => {
     "i",
     // "Hidden" args
     "teamSize",
-    `const GAME_SIZE = ${GAME_SIZE}; return ${fnString}`
+    `const GAME_SIZE = ${GAME_SIZE}; ${fnString}`
   );
 };
 

--- a/src/components/TeamFunctionInput.vue
+++ b/src/components/TeamFunctionInput.vue
@@ -4,7 +4,6 @@
       <p>
         <span class="lang-style-1">function</span>
         <span class="lang-style-2"> placeX</span>(i) {<br />
-        <span class="indent lang-style-1">return</span>
       </p>
       <textarea
         :value="props.team.placeX"
@@ -16,7 +15,6 @@
       <p>
         <span class="lang-style-1">function</span>
         <span class="lang-style-2"> placeY</span>(i) {<br />
-        <span class="indent lang-style-1">return</span>
       </p>
       <textarea
         :value="props.team.placeY"
@@ -28,7 +26,6 @@
       <p>
         <span class="lang-style-1">function</span>
         <span class="lang-style-2"> moveX</span>(t, i, x, y, vx, vy) {<br />
-        <span class="indent lang-style-1">return</span>
       </p>
       <textarea
         :value="props.team.moveX"
@@ -40,7 +37,6 @@
       <p>
         <span class="lang-style-1">function</span>
         <span class="lang-style-2"> moveY</span>(t, i, x, y, vx, vy) {<br />
-        <span class="indent lang-style-1">return</span>
       </p>
       <textarea
         :value="props.team.moveY"
@@ -108,7 +104,7 @@ const update = (key, value) => {
   background: #383e42;
   color: #dcdcdc;
   width: calc(100% - 1em);
-  min-height: 3em;
+  min-height: 5em;
 }
 
 .code-input .lang-style-1 {


### PR DESCRIPTION
Updates the function editors so that `return` is not implicit.

Example:
```
eyJtb3ZlWCI6ImlmICh2eCA+IDApIHtcbiAgaWYgKHggPj0gR0FNRV9TSVpFIC0gMSkge1xuICAgIHJldHVybiAtMTtcbiAgfVxuICByZXR1cm4gMTtcbn1cblxuaWYgKHZ4IDwgMCkge1xuICBpZiAoeCA8PSAwKSB7XG4gICAgcmV0dXJuIDE7XG4gIH1cbiAgcmV0dXJuIC0xO1xufVxuXG5yZXR1cm4gMTtcbiIsIm1vdmVZIjoicmV0dXJuIDEiLCJwbGFjZVgiOiJyZXR1cm4gaSAqIChHQU1FX1NJWkUgLyB0ZWFtU2l6ZSkiLCJwbGFjZVkiOiJyZXR1cm4gMCJ9
```