### PR TITLE
Pass list of neighbors to players

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -105,9 +105,6 @@ let isPaused = ref(false);
 let isPlaying = ref(false);
 
 let field = reactive(playField);
-// let teamOnePlayers = ref([])
-// let teamTwoPlayers = ref([])
-// let points = ref([])
 let teamOneScore = ref(0)
 let teamTwoScore = ref(0)
 

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,3 +1,5 @@
 export const GAME_SIZE = 60;
 
+export const PLAYER_VISION = 6;
+
 export const MAX_TIME_NO_ACTION = 1000 * 30; // 30s

--- a/src/common/game-state.js
+++ b/src/common/game-state.js
@@ -5,3 +5,9 @@ export const playField = {
   teamTwoPlayers: [],
   flags: [],
 };
+
+export const neighborType = {
+  TEAM: 1,
+  ENEMY: -1,
+  FLAG: 0,
+}

--- a/src/common/team.js
+++ b/src/common/team.js
@@ -63,8 +63,8 @@ export const updateTeam = (players, fnX, fnY, time, score = 0) => {
 };
 
 const neighborData = (playerX, playerY, otherX, otherY) => {
-  const xRel = Math.ceil(otherX - playerX);
-  const yRel = Math.ceil(otherY - playerY);
+  const xRel = Math.round(otherX - playerX);
+  const yRel = Math.round(otherY - playerY);
   const xDiff = Math.abs(xRel);
   const yDiff = Math.abs(yRel);
   const inVision = xDiff + yDiff > 0 && xDiff <= PLAYER_VISION && yDiff <= PLAYER_VISION;

--- a/src/common/team.js
+++ b/src/common/team.js
@@ -1,6 +1,7 @@
 import safeEval from "../modules/notevil";
-import { GAME_SIZE } from "./constants";
+import { GAME_SIZE, PLAYER_VISION } from "./constants";
 import { wrapInGrid } from "./math";
+import { playField, neighborType } from "./game-state"; // TODO: Is there a better way to share this state?
 
 export const createMoveFunction = (fnString) => {
   return safeEval.Function(
@@ -10,6 +11,7 @@ export const createMoveFunction = (fnString) => {
     "y",
     "vx",
     "vy",
+    "neighbors",
     // "Hidden" args
     "teamSize",
     "teamPoints",
@@ -30,8 +32,24 @@ export const updateTeam = (players, fnX, fnY, time, score = 0) => {
   return players.map((player, index) => {
     const { x, y, vx, vy } = player;
 
-    const outputX = fnX(time, index, x, y, vx, vy, players.length, score);
-    const outputY = fnY(time, index, x, y, vx, vy, players.length, score);
+    const teamOneType = JSON.stringify(playField.teamOnePlayers) == JSON.stringify(players) 
+      ? neighborType.TEAM 
+      : neighborType.ENEMY;
+    const teamTwoType = teamOneType == neighborType.TEAM 
+      ? neighborType.ENEMY 
+      : neighborType.TEAM;
+
+    const neighbors =
+      playField.flags.map(f => ({ x: f.x, y: f.y, type: neighborType.FLAG }))
+      // TODO: map, filter, find, etc. not working so can't loop to check neighbor type
+      // .concat(playField.teamOnePlayers.map(p => ({ x: p.x, y: p.y, type: teamOneType })))
+      // .concat(playField.teamTwoPlayers.map(p => ({ x: p.x, y: p.y, type: teamTwoType })))
+      .map(n => ({...n, ...neighborData(x, y, n.x, n.y)}))
+      .filter(r => r.inVision)
+      .map(r => ({ x: r.x, y: r.y, type: r.type }))
+
+    const outputX = fnX(time, index, x, y, vx, vy, neighbors, players.length, score);
+    const outputY = fnY(time, index, x, y, vx, vy, neighbors, players.length, score);
     const moveX = outputX > 0 ? 1 : outputX < 0 ? -1 : 0;
     const moveY = outputY > 0 ? 1 : outputY < 0 ? -1 : 0;
 
@@ -43,6 +61,20 @@ export const updateTeam = (players, fnX, fnY, time, score = 0) => {
     };
   });
 };
+
+const neighborData = (playerX, playerY, otherX, otherY) => {
+  const xRel = Math.ceil(otherX - playerX);
+  const yRel = Math.ceil(otherY - playerY);
+  const xDiff = Math.abs(xRel);
+  const yDiff = Math.abs(yRel);
+  const inVision = xDiff + yDiff > 0 && xDiff <= PLAYER_VISION && yDiff <= PLAYER_VISION;
+    
+  return {
+    inVision,
+    x: xRel,
+    y: yRel,
+  }
+}
 
 export const placeTeam = (teamSize, fnX, fnY) => {
   const newTeam = [];

--- a/src/components/TeamFunctionInput.vue
+++ b/src/components/TeamFunctionInput.vue
@@ -33,7 +33,7 @@
     <div class="code-input">
       <p>
         <span class="lang-style-1">function</span>
-        <span class="lang-style-2"> moveX</span>(t, i, x, y, vx, vy) {<br />
+        <span class="lang-style-2"> moveX</span>(t, i, x, y, vx, vy, neighbors) {<br />
       </p>
       <code-docs>// Updates player x-position each tick.
         <br>// t: total time elapsed
@@ -41,7 +41,8 @@
         <br>// x: current x-position
         <br>// y: current y-position
         <br>// vx: previous move update x-axis
-        <br>// yx: previous move update y-axis
+        <br>// vy: previous move update y-axis
+        <br>// neighbors: flags {x,y} within 6 units
         <br>// @returns 0, 1, or -1
       </code-docs>
       <textarea
@@ -53,7 +54,7 @@
     <div class="code-input">
       <p>
         <span class="lang-style-1">function</span>
-        <span class="lang-style-2"> moveY</span>(t, i, x, y, vx, vy) {<br />
+        <span class="lang-style-2"> moveY</span>(t, i, x, y, vx, vy, neighbors) {<br />
       </p>
       <code-docs>// Updates player y-position each tick.
         <br>// t: total time elapsed
@@ -61,7 +62,8 @@
         <br>// x: current x-position
         <br>// y: current y-position
         <br>// vx: previous move update x-axis
-        <br>// yx: previous move update y-axis
+        <br>// vy: previous move update y-axis
+        <br>// neighbors: flags {x,y} within 6 units
         <br>// @returns 0, 1, or -1
       </code-docs>
       <textarea

--- a/src/modules/notevil/lib/built-ins.js
+++ b/src/modules/notevil/lib/built-ins.js
@@ -1,17 +1,8 @@
-import { playField } from "../../../common/game-state"; // TODO: Is there a better way to share this state?
-
 const clamp = (num, min, max) => Math.min(Math.max(num, min), max);
 const lerp = (a, b, t) => (b - a) * t + a;
 const unlerp = (a, b, t) => (t - a) / (b - a);
 const remap = (num, inMin, inMax, outMin, outMax) =>
   lerp(outMin, outMax, unlerp(inMin, inMax, num));
-
-function look(vX, vY) {
-  // WIP
-
-  vX = clamp(Math.round(vX), -1, 1);
-  vY = clamp(Math.round(vY), -1, 1);
-}
 
 export const builtIns = {
   // PI: Math.PI, not working for me for some reason
@@ -39,5 +30,4 @@ export const builtIns = {
   lerp,
   unlerp,
   remap,
-  // look
 };


### PR DESCRIPTION
This adds a `neighbors` param to the player functions. I commented out teammates and enemies for now since I couldn't get `filter`, `find`, or `for` loops to work so it wasn't possible to search for only one type of neighbor. So for now the neighbors will only be flags.

Players can only see 6 units away and this is configurable with `PLAYER_VISION`.

```js
// Move X
const flag = neighbors[0]
return flag 
  ? flag.x 
  : remap(random(), 0, 1, -1, 1)

// Move Y
const flag = neighbors[0]
return flag && flag.x != 1
  ? flag.y
  : remap(random(), 0, 1, -1, 1)
```

### Example:
```
eyJtb3ZlWCI6ImNvbnN0IGZsYWcgPSBuZWlnaGJvcnNbMF1cbnJldHVybiBmbGFnIFxuICA/IGZsYWcueCBcbiAgOiByZW1hcChyYW5kb20oKSwgMCwgMSwgLTEsIDEpIiwibW92ZVkiOiJjb25zdCBmbGFnID0gbmVpZ2hib3JzWzBdXG5yZXR1cm4gZmxhZyAmJiBmbGFnLnggIT0gMVxuICA/IGZsYWcueVxuICA6IHJlbWFwKHJhbmRvbSgpLCAwLCAxLCAtMSwgMSkiLCJwbGFjZVgiOiJyZXR1cm4gcmFuZG9tKCkgKiA1OSIsInBsYWNlWSI6InJldHVybiByYW5kb20oKSAqIDU5In0=
```

![code-sports-flag-seekers](https://user-images.githubusercontent.com/5971687/218228642-8a8bbd40-347d-43ff-923d-95e944bcf50c.gif)

### Knows Issues:
For some reason players will rarely get stuck a single unit away from a flag. I'm not sure yet what causes this to happen. 
